### PR TITLE
Extend API with callback to signal events

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,28 @@ if (doki != null) doki.loadContent();
 </p>
 </details>
 
+You can pass a `DokiContentCallback` instance to the `loadContent` method to receive events:
+
+<details open>
+<summary>Kotlin</summary>
+<p>
+
+```kotlin
+val doki : DokiContentView? = findViewById(R.id.doki_content)
+doki?.loadContent(callback = object : DokiContentCallback {
+    override fun onStartedToLoad() {}
+    override fun onLoaded() {}
+    override fun onFailedToLoad() {}
+})
+```
+
+</p>
+</details>
+
 ## Customization
 
 If you are using the `DokiContentView`, you can customize it by setting custom attributes.
-Please check [this file](https://github.com/DoubleDotLabs/doki/blob/master/app/src/main/res/layout/layout_doki_view_custom.xml)
+Please check [this file](https://github.com/doubledotlabs/doki/blob/master/sample/src/main/res/layout/activity_doki_custom.xml)
 which implements every option available.
 
 For custom fonts and text styles, you can override the following styles:
@@ -135,6 +153,9 @@ For custom fonts and text styles, you can override the following styles:
 <style name="Doki.Custom.Headline" parent="Doki.Headline"/>
 <style name="Doki.Custom.Overline" parent="Doki.Overline"/>
 <style name="Doki.Custom.Button" parent="Doki.Button"/>
+<style name="Doki.Custom.Body" parent="Doki.Body"/>
+<style name="Doki.Custom.Header" parent="Doki.Header"/>
+<style name="Doki.Custom.Subtext" parent="Doki.Subtext"/>
 ```
 
 And add the following attributes as you wish and with the values you want:

--- a/api/src/main/java/dev/doubledot/doki/api/extensions/Android.kt
+++ b/api/src/main/java/dev/doubledot/doki/api/extensions/Android.kt
@@ -3,14 +3,14 @@ package dev.doubledot.doki.api.extensions
 import android.os.Build
 import android.os.Build.VERSION_CODES.*
 
-val androidVersion: String
+internal val androidVersion: String
     get() {
         var version = Build.VERSION.RELEASE ?: ""
         if (!version.hasContent()) version = Build.VERSION.CODENAME ?: ""
         return version
     }
 
-val androidVersionName: String
+internal val androidVersionName: String
     get() {
         return when (Build.VERSION.SDK_INT) {
             JELLY_BEAN, JELLY_BEAN_MR1, JELLY_BEAN_MR2 -> "JellyBean"

--- a/api/src/main/java/dev/doubledot/doki/api/extensions/String.kt
+++ b/api/src/main/java/dev/doubledot/doki/api/extensions/String.kt
@@ -3,7 +3,7 @@ package dev.doubledot.doki.api.extensions
 import java.math.RoundingMode
 import java.text.DecimalFormat
 
-fun String.hasContent() = isNotEmpty() && isNotBlank()
+internal fun String.hasContent() = isNotEmpty() && isNotBlank()
 
 internal fun Number.round(decimalCount: Int): String {
     val expression = StringBuilder().append("#.")

--- a/api/src/main/java/dev/doubledot/doki/api/remote/DokiApiService.kt
+++ b/api/src/main/java/dev/doubledot/doki/api/remote/DokiApiService.kt
@@ -9,7 +9,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.GET
 import retrofit2.http.Path
 
-interface DokiApiService {
+internal interface DokiApiService {
 
     @GET("{manufacturer}.json")
     fun getManufacturer(@Path("manufacturer") manufacturer : String) : Observable<DokiManufacturer>

--- a/api/src/main/java/dev/doubledot/doki/api/tasks/DokiApi.kt
+++ b/api/src/main/java/dev/doubledot/doki/api/tasks/DokiApi.kt
@@ -17,7 +17,7 @@ class DokiApi {
     }
 
     private var disposable: Disposable? = null
-    
+
     fun getManufacturer(
         manufacturer: String = DONT_KILL_MY_APP_DEFAULT_MANUFACTURER,
         callback: DokiApiCallback,

--- a/api/src/main/java/dev/doubledot/doki/api/tasks/DokiApi.kt
+++ b/api/src/main/java/dev/doubledot/doki/api/tasks/DokiApi.kt
@@ -10,31 +10,36 @@ import io.reactivex.schedulers.Schedulers
 import retrofit2.HttpException
 
 @Suppress("MemberVisibilityCanBePrivate")
-open class DokiApi {
+class DokiApi {
 
-    val dokiApiService by lazy {
+    private val dokiApiService by lazy {
         DokiApiService.create()
     }
 
-    var disposable: Disposable? = null
-    var callback: DokiApiCallback? = null
-    var shouldFallback : Boolean = true
-
-    fun getManufacturer(manufacturer : String = DONT_KILL_MY_APP_DEFAULT_MANUFACTURER) {
+    private var disposable: Disposable? = null
+    
+    fun getManufacturer(
+        manufacturer: String = DONT_KILL_MY_APP_DEFAULT_MANUFACTURER,
+        callback: DokiApiCallback,
+        shouldFallback: Boolean = true
+    ) {
         disposable = dokiApiService.getManufacturer(manufacturer)
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(
-                { result : DokiManufacturer -> callback?.onSuccess(result) },
+                { result: DokiManufacturer -> callback.onSuccess(result) },
                 { error ->
                     if ((error as? HttpException)?.code() == 404 && shouldFallback) {
-                        getManufacturer(DONT_KILL_MY_APP_FALLBACK_MANUFACTURER)
-                        shouldFallback = false
-                    } else callback?.onError(error)
+                        getManufacturer(
+                            DONT_KILL_MY_APP_FALLBACK_MANUFACTURER,
+                            callback,
+                            shouldFallback = false
+                        )
+                    } else callback.onError(error)
                 }
             )
 
-        callback?.onStart()
+        callback.onStart()
     }
 
     fun cancel() {

--- a/api/src/main/java/dev/doubledot/doki/api/tasks/DokiApiCallback.kt
+++ b/api/src/main/java/dev/doubledot/doki/api/tasks/DokiApiCallback.kt
@@ -5,5 +5,8 @@ import dev.doubledot.doki.api.models.DokiManufacturer
 interface DokiApiCallback {
     fun onStart() {}
     fun onSuccess(response: DokiManufacturer?)
-    fun onError(e: Throwable?) = e?.printStackTrace()
+
+    fun onError(e: Throwable?) {
+        e?.printStackTrace()
+    }
 }

--- a/library/src/main/java/dev/doubledot/doki/extensions/WebView.kt
+++ b/library/src/main/java/dev/doubledot/doki/extensions/WebView.kt
@@ -2,5 +2,5 @@ package dev.doubledot.doki.extensions
 
 import android.webkit.WebView
 
-fun WebView.loadHTML(htmlString: String?) = loadData(htmlString.orEmpty(), "text/html", null)
+internal fun WebView.loadHTML(htmlString: String?) = loadData(htmlString.orEmpty(), "text/html", null)
 

--- a/library/src/main/java/dev/doubledot/doki/models/Device.kt
+++ b/library/src/main/java/dev/doubledot/doki/models/Device.kt
@@ -3,7 +3,7 @@ package dev.doubledot.doki.models
 import android.os.Build
 import dev.doubledot.doki.api.extensions.fullAndroidVersion
 
-data class Device(
+internal data class Device(
     var manufacturer : String = Build.MANUFACTURER,
     var model : String = Build.MODEL,
     var androidVersion : String = fullAndroidVersion

--- a/library/src/main/java/dev/doubledot/doki/ui/DokiActivity.kt
+++ b/library/src/main/java/dev/doubledot/doki/ui/DokiActivity.kt
@@ -5,20 +5,17 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import dev.doubledot.doki.api.extensions.DONT_KILL_MY_APP_DEFAULT_MANUFACTURER
-import dev.doubledot.doki.api.tasks.DokiApi
 import dev.doubledot.doki.views.DokiContentView
 
-public class DokiActivity : AppCompatActivity() {
+class DokiActivity : AppCompatActivity() {
 
-    var api : DokiApi? = null
+    private val dokiView: DokiContentView by lazy { DokiContentView(context = this) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        val dokiView = DokiContentView(context = this)
         setContentView(dokiView)
 
-        api = dokiView.loadContent(manufacturerId = intent.extras?.run {
+        dokiView.loadContent(manufacturerId = intent.extras?.run {
             this[MANUFACTURER_EXTRA] as? String
         } ?: DONT_KILL_MY_APP_DEFAULT_MANUFACTURER)
 
@@ -27,22 +24,21 @@ public class DokiActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        api?.cancel()
+        dokiView.cancel()
     }
 
     companion object {
-
-        public const val MANUFACTURER_EXTRA = "dev.doubledot.doki.ui.DokiActivity.MANUFACTURER_EXTRA"
+        private const val MANUFACTURER_EXTRA = "dev.doubledot.doki.ui.DokiActivity.MANUFACTURER_EXTRA"
 
         @JvmOverloads
-        public fun newIntent(context: Context, manufacturerId: String = DONT_KILL_MY_APP_DEFAULT_MANUFACTURER): Intent {
+        fun newIntent(context: Context, manufacturerId: String = DONT_KILL_MY_APP_DEFAULT_MANUFACTURER): Intent {
             val intent = Intent(context, DokiActivity::class.java)
             intent.putExtra(MANUFACTURER_EXTRA, manufacturerId)
             return intent
         }
 
         @JvmOverloads
-        public fun start(context : Context, manufacturerId : String = DONT_KILL_MY_APP_DEFAULT_MANUFACTURER) {
+        fun start(context : Context, manufacturerId : String = DONT_KILL_MY_APP_DEFAULT_MANUFACTURER) {
             context.startActivity(newIntent(context, manufacturerId))
         }
     }

--- a/library/src/main/java/dev/doubledot/doki/ui/DokiContentCallback.kt
+++ b/library/src/main/java/dev/doubledot/doki/ui/DokiContentCallback.kt
@@ -1,0 +1,7 @@
+package dev.doubledot.doki.ui
+
+interface DokiContentCallback {
+    fun onStartedToLoad() {}
+    fun onLoaded() {}
+    fun onFailedToLoad() {}
+}

--- a/library/src/main/java/dev/doubledot/doki/views/DokiContentView.kt
+++ b/library/src/main/java/dev/doubledot/doki/views/DokiContentView.kt
@@ -19,6 +19,7 @@ import dev.doubledot.doki.api.tasks.DokiApi
 import dev.doubledot.doki.api.tasks.DokiApiCallback
 import dev.doubledot.doki.extensions.*
 import dev.doubledot.doki.models.Device
+import dev.doubledot.doki.ui.DokiContentCallback
 
 @Suppress("MemberVisibilityCanBePrivate")
 class DokiContentView @JvmOverloads constructor(
@@ -31,10 +32,10 @@ class DokiContentView @JvmOverloads constructor(
 
     // View bindings ---------------------------------------
 
-    private val appBarLayout : View? by bind(R.id.appbar)
-    private val footerLayout : View? by bind(R.id.footer)
+    private val appBarLayout: View? by bind(R.id.appbar)
+    private val footerLayout: View? by bind(R.id.footer)
 
-    private val headerBackground : View? by bind(R.id.headerBackground)
+    private val headerBackground: View? by bind(R.id.headerBackground)
 
     private val deviceManufacturerHeader: TextView? by bind(R.id.deviceManufacturerHeader)
     private val deviceManufacturer: TextView? by bind(R.id.deviceManufacturer)
@@ -49,18 +50,18 @@ class DokiContentView @JvmOverloads constructor(
     private val manufacturerRating: DokiRatingView? by bind(R.id.manufacturerRating)
 
     private val contentLoadingView: ProgressBar? by bind(R.id.contentLoadingView)
-    private val contentScrollView : View? by bind(R.id.contentScrollView)
+    private val contentScrollView: View? by bind(R.id.contentScrollView)
 
-    private val contentExplanationHeader : TextView? by bind(R.id.contentExplanationHeader)
-    private val contentExplanation : DokiHtmlTextView? by bind(R.id.contentExplanation)
+    private val contentExplanationHeader: TextView? by bind(R.id.contentExplanationHeader)
+    private val contentExplanation: DokiHtmlTextView? by bind(R.id.contentExplanation)
 
-    private val contentSolutionHeader : TextView? by bind(R.id.contentSolutionHeader)
-    private val contentSolution : DokiHtmlTextView? by bind(R.id.contentSolution)
+    private val contentSolutionHeader: TextView? by bind(R.id.contentSolutionHeader)
+    private val contentSolution: DokiHtmlTextView? by bind(R.id.contentSolution)
 
-    private val contentDeveloperSolutionHeader : TextView? by bind(R.id.contentDeveloperSolutionHeader)
-    private val contentDeveloperSolution : DokiHtmlTextView? by bind(R.id.contentDeveloperSolution)
+    private val contentDeveloperSolutionHeader: TextView? by bind(R.id.contentDeveloperSolutionHeader)
+    private val contentDeveloperSolution: DokiHtmlTextView? by bind(R.id.contentDeveloperSolution)
 
-    private val contentAttribution : DokiHtmlTextView? by bind(R.id.contentAttribution)
+    private val contentAttribution: DokiHtmlTextView? by bind(R.id.contentAttribution)
 
     private val buttonContainer: View? by bind(R.id.buttonContainer)
     private val closeBtn: TextView? by bind(R.id.buttonClose)
@@ -147,7 +148,7 @@ class DokiContentView @JvmOverloads constructor(
             field = value
         }
 
-    var iconsStyle : DokiRatingView.Style? = DokiRatingView.Style.THUMB
+    var iconsStyle: DokiRatingView.Style? = DokiRatingView.Style.THUMB
         set(value) {
             value?.let {
                 activeIconsDrawable = try {
@@ -178,7 +179,7 @@ class DokiContentView @JvmOverloads constructor(
             field = value
         }
 
-    var lineHeight : Float = 1F
+    var lineHeight: Float = 1F
         set(value) {
             contentExplanation?.setLineSpacing(lineSeparation, value)
             contentSolution?.setLineSpacing(lineSeparation, value)
@@ -186,7 +187,7 @@ class DokiContentView @JvmOverloads constructor(
             field = value
         }
 
-    var lineSeparation : Float = 0F
+    var lineSeparation: Float = 0F
         set(value) {
             field = value
             lineHeight = lineHeight
@@ -195,10 +196,10 @@ class DokiContentView @JvmOverloads constructor(
     // Data / models ------------------------------------
 
     private var devSolutionMessage: String = ""
-    var explanationTitleText: String = ""
-    var solutionTitleText: String = ""
+    private var explanationTitleText: String = ""
+    private var solutionTitleText: String = ""
 
-    var device : Device? = null
+    private var device: Device? = null
         set(value) {
             field = value
             value ?: return
@@ -208,7 +209,7 @@ class DokiContentView @JvmOverloads constructor(
             deviceAndroidVersion?.text = value.androidVersion
         }
 
-    var manufacturer : DokiManufacturer? = null
+    private var manufacturer: DokiManufacturer? = null
         set(value) {
             field = value
             value ?: return
@@ -254,16 +255,33 @@ class DokiContentView @JvmOverloads constructor(
 
         // Styling
 
-        primaryTextColor = styledAttrs?.getColorOrNull(R.styleable.DokiContentView_dokiPrimaryTextColor) ?: primaryTextColor
-        secondaryTextColor = styledAttrs?.getColorOrNull(R.styleable.DokiContentView_dokiSecondaryTextColor) ?: secondaryTextColor
-        buttonsTextColor = styledAttrs?.getColorOrNull(R.styleable.DokiContentView_dokiButtonsTextColor) ?: buttonsTextColor
-        dividerColor = styledAttrs?.getColorOrNull(R.styleable.DokiContentView_dokiDividerColor) ?: dividerColor
-        headerBackgroundColor = styledAttrs?.getColorOrNull(R.styleable.DokiContentView_dokiHeaderBackgroundColor) ?: headerBackgroundColor
-        activeIconsDrawable = styledAttrs?.getDrawableOrNull(R.styleable.DokiContentView_dokiActiveIconsDrawable) ?: activeIconsDrawable
-        inactiveIconsDrawable = styledAttrs?.getDrawableOrNull(R.styleable.DokiContentView_dokiInactiveIconsDrawable) ?: inactiveIconsDrawable
+        primaryTextColor =
+            styledAttrs?.getColorOrNull(R.styleable.DokiContentView_dokiPrimaryTextColor)
+                ?: primaryTextColor
+        secondaryTextColor =
+            styledAttrs?.getColorOrNull(R.styleable.DokiContentView_dokiSecondaryTextColor)
+                ?: secondaryTextColor
+        buttonsTextColor =
+            styledAttrs?.getColorOrNull(R.styleable.DokiContentView_dokiButtonsTextColor)
+                ?: buttonsTextColor
+        dividerColor = styledAttrs?.getColorOrNull(R.styleable.DokiContentView_dokiDividerColor)
+            ?: dividerColor
+        headerBackgroundColor =
+            styledAttrs?.getColorOrNull(R.styleable.DokiContentView_dokiHeaderBackgroundColor)
+                ?: headerBackgroundColor
+        activeIconsDrawable =
+            styledAttrs?.getDrawableOrNull(R.styleable.DokiContentView_dokiActiveIconsDrawable)
+                ?: activeIconsDrawable
+        inactiveIconsDrawable =
+            styledAttrs?.getDrawableOrNull(R.styleable.DokiContentView_dokiInactiveIconsDrawable)
+                ?: inactiveIconsDrawable
         iconsStyle = getStyledIconsStyle(styledAttrs) ?: iconsStyle
-        activeIconsColor = styledAttrs?.getColorOrNull(R.styleable.DokiContentView_dokiActiveIconsColor) ?: activeIconsColor
-        inactiveIconsColor = styledAttrs?.getColorOrNull(R.styleable.DokiContentView_dokiInactiveIconsColor) ?: inactiveIconsColor
+        activeIconsColor =
+            styledAttrs?.getColorOrNull(R.styleable.DokiContentView_dokiActiveIconsColor)
+                ?: activeIconsColor
+        inactiveIconsColor =
+            styledAttrs?.getColorOrNull(R.styleable.DokiContentView_dokiInactiveIconsColor)
+                ?: inactiveIconsColor
         lineHeight = 1F
         lineSeparation = 8F.dpToPx
 
@@ -275,7 +293,8 @@ class DokiContentView @JvmOverloads constructor(
             ""
         }
         explanationTitleText = try {
-            styledAttrs?.getString(R.styleable.DokiContentView_dokiExplanationTitle) ?: defaultExplanationTitleText
+            styledAttrs?.getString(R.styleable.DokiContentView_dokiExplanationTitle)
+                ?: defaultExplanationTitleText
         } catch (e: Exception) {
             defaultExplanationTitleText
         }
@@ -286,7 +305,8 @@ class DokiContentView @JvmOverloads constructor(
             ""
         }
         solutionTitleText = try {
-            styledAttrs?.getString(R.styleable.DokiContentView_dokiSolutionTitle) ?: defaultSolutionTitleText
+            styledAttrs?.getString(R.styleable.DokiContentView_dokiSolutionTitle)
+                ?: defaultSolutionTitleText
         } catch (e: Exception) {
             defaultSolutionTitleText
         }
@@ -302,15 +322,31 @@ class DokiContentView @JvmOverloads constructor(
         styledAttrs?.recycle()
     }
 
-    fun loadContent(manufacturerId: String = DONT_KILL_MY_APP_DEFAULT_MANUFACTURER) : DokiApi {
-        api.callback = object: DokiApiCallback {
+    fun loadContent(
+        manufacturerId: String = DONT_KILL_MY_APP_DEFAULT_MANUFACTURER,
+        callback: DokiContentCallback? = null
+    ) {
+        api.getManufacturer(manufacturerId, object : DokiApiCallback {
             override fun onSuccess(response: DokiManufacturer?) {
-                manufacturer = response
+                response?.let {
+                    manufacturer = response
+                    callback?.onLoaded()
+                } ?: callback?.onFailedToLoad()
             }
-        }
-        api.getManufacturer(manufacturerId)
 
-        return api
+            override fun onStart() {
+                callback?.onStartedToLoad()
+            }
+
+            override fun onError(e: Throwable?) {
+                super.onError(e)
+                callback?.onFailedToLoad()
+            }
+        })
+    }
+
+    fun cancel() {
+        api.cancel()
     }
 
     override fun onDetachedFromWindow() {
@@ -327,7 +363,7 @@ class DokiContentView @JvmOverloads constructor(
         divider2?.visibleIf(visible)
     }
 
-    private fun getStyledIconsStyle(attrs : TypedArray?) : DokiRatingView.Style? {
+    private fun getStyledIconsStyle(attrs: TypedArray?): DokiRatingView.Style? {
         val iconsStyleId = try {
             attrs?.getInt(R.styleable.DokiContentView_dokiIconsStyle, -1) ?: -1
         } catch (e: Exception) {

--- a/library/src/main/java/dev/doubledot/doki/views/DokiContentView.kt
+++ b/library/src/main/java/dev/doubledot/doki/views/DokiContentView.kt
@@ -11,6 +11,7 @@ import android.view.View
 import android.widget.LinearLayout
 import android.widget.ProgressBar
 import android.widget.TextView
+import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
 import dev.doubledot.doki.R
 import dev.doubledot.doki.api.extensions.DONT_KILL_MY_APP_DEFAULT_MANUFACTURER
@@ -235,8 +236,7 @@ class DokiContentView @JvmOverloads constructor(
         }
 
     init {
-        val inflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
-        inflater.inflate(R.layout.doki_view_content, this, true)
+        LayoutInflater.from(context).inflate(R.layout.doki_view_content, this, true)
         rootBackgroundColor = Color.WHITE
 
         contentAttribution?.htmlText = context.getString(R.string.doki_content_attribution)

--- a/sample/src/main/java/dev/doubledot/doki/app/DokiThemedActivity.kt
+++ b/sample/src/main/java/dev/doubledot/doki/app/DokiThemedActivity.kt
@@ -2,6 +2,7 @@ package dev.doubledot.doki.app
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import dev.doubledot.doki.ui.DokiContentCallback
 import dev.doubledot.doki.views.DokiContentView
 
 class DokiThemedActivity : AppCompatActivity() {
@@ -15,7 +16,11 @@ class DokiThemedActivity : AppCompatActivity() {
         setContentView(R.layout.activity_doki)
 
         dokiContent?.setOnCloseListener { supportFinishAfterTransition() }
-        dokiContent?.loadContent()
+        dokiContent?.loadContent(callback = object : DokiContentCallback {
+            override fun onStartedToLoad() {}
+            override fun onLoaded() {}
+            override fun onFailedToLoad() {}
+        })
     }
 
 }

--- a/versions.gradle
+++ b/versions.gradle
@@ -10,9 +10,9 @@ ext.deps = [
     buildtools: '3.4.0',
     kotlin: '1.3.21',
     android: [
-        appcompat: '1.0.2',
+        appcompat: '1.1.0',
         material: '1.0.0',
-        constraintlayout: '1.1.2'
+        constraintlayout: '1.1.3'
     ],
     retrofit: '2.3.0',
     rxandroid: '2.1.1',


### PR DESCRIPTION
**Issue:** The caller of the `DokiContentView` API is not aware of any error while loading content.
**Resolution:** `DokiContentView::loadContent()` can receive a callback object (`DokiContentCallback`) to which `DokiApiCallback` events are translated. This allows the caller to be notified about events regarding content loading. In the future the library should use these events to handle errors and display them on the UI in `DokiActivity`.